### PR TITLE
Mail everyone

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "informerad",
+  "name": "@d-sektionen/informerad",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/src/commands/send.ts
+++ b/src/commands/send.ts
@@ -16,6 +16,7 @@ import writeToFiles from "../modules/writeToFiles";
 import mailgunSender from "../modules/mailgunSender";
 import recipientExporter from "../modules/recipientExporter";
 import djangoBackendUserRetriever from "../modules/djangoBackendUserRetriever";
+import djangoBackendAllUserRetriever from "../modules/djangoBackendAllUserRetriever";
 import Setting from "../utils/settings";
 import State from "../utils/state";
 
@@ -46,6 +47,9 @@ export default class SendCommand extends Command {
     django_backend: flags.boolean({
       description: "retrieve recipients from the D-sektionen Django backend",
     }),
+    django_all_backend: flags.boolean({
+      description: "retrieve all recipients from the D-sektionen Django backend",
+    }),
     // wp: flags.boolean({
     //   description: "retrieve recipients from Wordpress",
     // }),
@@ -73,6 +77,7 @@ export default class SendCommand extends Command {
     test: flags.boolean({
       description: "enable mailgun test mode",
     }),
+
     export_recipients: flags.string({
       description: "path to json file which recipients are exported to.",
     }),
@@ -83,6 +88,7 @@ export default class SendCommand extends Command {
     const { flags } = this.parse(SendCommand);
     const {
       django_backend,
+      django_all_backend,
       // wp,
       recipients,
       content,
@@ -155,6 +161,17 @@ export default class SendCommand extends Command {
     //   });
     //   cli.action.stop();
     // }
+
+    // Get all recipients from the django backend if flag present.
+    // TODO might cause duplicates if both django_all_backend and django_backend is true, but just don't do that?
+    if (django_all_backend) {
+      cli.action.start("Retrieving all Django backend users");
+      await djangoBackendAllUserRetriever(
+        state,
+        await Setting.DJANGO_TOKEN.getValue(this.config.configDir)
+      );
+      cli.action.stop();
+    }
 
     // Get recipients from the django backend if flag present.
     if (django_backend) {

--- a/src/commands/send.ts
+++ b/src/commands/send.ts
@@ -47,7 +47,7 @@ export default class SendCommand extends Command {
     django_backend: flags.boolean({
       description: "retrieve recipients from the D-sektionen Django backend",
     }),
-    django_all_backend: flags.boolean({
+    django_everyone_backend: flags.boolean({
       description: "retrieve all recipients from the D-sektionen Django backend",
     }),
     // wp: flags.boolean({
@@ -88,7 +88,7 @@ export default class SendCommand extends Command {
     const { flags } = this.parse(SendCommand);
     const {
       django_backend,
-      django_all_backend,
+      django_everyone_backend,
       // wp,
       recipients,
       content,
@@ -163,9 +163,8 @@ export default class SendCommand extends Command {
     // }
 
     // Get all recipients from the django backend if flag present.
-    // TODO might cause duplicates if both django_all_backend and django_backend is true, but just don't do that?
-    if (django_all_backend) {
-      cli.action.start("Retrieving all Django backend users");
+    if (django_everyone_backend) {
+      cli.action.start("Retrieving EVERYONE. (Even non-subscribers)");
       await djangoBackendAllUserRetriever(
         state,
         await Setting.DJANGO_TOKEN.getValue(this.config.configDir)
@@ -174,8 +173,8 @@ export default class SendCommand extends Command {
     }
 
     // Get recipients from the django backend if flag present.
-    if (django_backend) {
-      cli.action.start("Retrieving Django backend users");
+    else if (django_backend ) {
+      cli.action.start("Retrieving all subscribed users");
       await djangoBackendUserRetriever(
         state,
         await Setting.DJANGO_TOKEN.getValue(this.config.configDir)

--- a/src/modules/djangoBackendAllUserRetriever.ts
+++ b/src/modules/djangoBackendAllUserRetriever.ts
@@ -18,7 +18,7 @@ const djangoBackendAllUserRetriever = async (
 
   state.addRecipients(
     res.data.map(
-      (user: { email: string; pretty_name: string }) =>
+      (user: { email: string; pretty_name: string }) => 
         new Recipient(user.email, user.pretty_name)
     )
   );

--- a/src/modules/djangoBackendAllUserRetriever.ts
+++ b/src/modules/djangoBackendAllUserRetriever.ts
@@ -1,0 +1,27 @@
+import axios from "axios";
+import State from "../utils/state";
+import { Recipient } from "../utils/models";
+
+const ENDPOINT = "https://backend.d-sektionen.se/account/infomail-everyone/";
+
+const axiosOptions = (token: string) => ({
+  headers: {
+    Authorization: `Token ${token}`,
+  },
+});
+
+const djangoBackendAllUserRetriever = async (
+  state: State,
+  token: string
+): Promise<void> => {
+  const res = await axios.get(ENDPOINT, axiosOptions(token));
+
+  state.addRecipients(
+    res.data.map(
+      (user: { email: string; pretty_name: string }) =>
+        new Recipient(user.email, user.pretty_name)
+    )
+  );
+};
+
+export default djangoBackendAllUserRetriever;


### PR DESCRIPTION
## Flag django_everyone_backend added to SEND.
Gets all users from django backend via the soon to be deployed ./account/infomail-everyone/
Requested feature to be able to mail everyone, including non-subscribed


 As well as some small text changes to django_backend flag to match the new flag